### PR TITLE
Update build_proc_call_query to support named params in functions

### DIFF
--- a/results/connections.py
+++ b/results/connections.py
@@ -15,10 +15,11 @@ from .resultset import resultproxy_to_results
 def build_proc_call_query(_proc_name, *args, **kwargs):
     _proc_name = _proc_name.replace("__", ".")
     params = {f"positional{i}": x for i, x in enumerate(args)}
-    params.update(**dict(kwargs))
     paramnames = params.keys()
     bindparams = [f":{name}" for name in list(paramnames)]
+    bindparams.extend([f"{key} => :{key}" for key in dict(kwargs).keys()])
     paramspec = ", ".join(bindparams)
+    params.update(**dict(kwargs))
     query = f"select * from {_proc_name}({paramspec})"
     return query, params
 

--- a/tests/FIXTURES/sql/functions.sql
+++ b/tests/FIXTURES/sql/functions.sql
@@ -1,12 +1,13 @@
-
-CREATE or replace FUNCTION films_f(d date,
-def_t text default null,
-def_d date default '2014-01-01'::date)
+-- function which takes one positional arg and two named args with defaults
+CREATE or replace FUNCTION films_f(title text,
+    is_feature boolean default true,
+    duration integer default 180)
 RETURNS TABLE(
     title character varying,
-    release_date date
+    is_feature boolean,
+    duration integer
 )
-as $$select 'a'::varchar, '2014-01-01'::date$$
+as $$select title, is_feature, duration$$
 language sql;
 
 CREATE OR REPLACE FUNCTION inc_f(integer) RETURNS integer AS $$

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from pytest import raises
+from sqlalchemy.exc import ProgrammingError
 
 import results
 from results import db
@@ -52,6 +53,25 @@ def test_function_calls(tmpdbwithfunctions):
     with tmpdb.transaction() as t:
         result = t.procs.inc_f(1)
         assert result.scalar() == 2
+
+
+def test_function_calls_with_default_args(tmpdbwithfunctions):
+    tmpdb = db(tmpdbwithfunctions)
+
+    def callfunc(*args, **kwargs):
+        return list(tmpdb.procs.films_f(*args, **kwargs).one().values())
+
+    with raises(ProgrammingError):
+        callfunc()
+
+    # providing only 1 arg returns 2 defaults
+    assert callfunc("test") == ["test", True, 180]
+    # providing all args as positional returns provided values
+    assert callfunc("test", False, 99) == ["test", False, 99]
+    # providing combo of positional and named args works
+    assert callfunc("test", is_feature=False, duration=99) == ["test", False, 99]
+    # omitting one named parameter returns default and still accepts the other
+    assert callfunc("test", duration=99) == ["test", True, 99]
 
 
 def test_result_object(tmpdir, sample):


### PR DESCRIPTION
The `build_proc_call_query` function treats all arguments as positional, which means that if a function allows default values for some args, we still have to provide a full list when calling it via `procs`. We can't currently provide non-default values for some args but leave others unspecified, because all args are passed to the function as a positional list. This change uses mixed notation to provide the positional args positionally and the named ones with names.